### PR TITLE
Remove JS module information printed on the console

### DIFF
--- a/mtp_prisoner_location_admin/assets-src/javascripts/main.js
+++ b/mtp_prisoner_location_admin/assets-src/javascripts/main.js
@@ -18,12 +18,4 @@
       require('unload')
     ])
     .init();
-
-  var moduleNames = Object.keys(Mojular.Modules);
-  if(moduleNames.length) {
-    var moduleList = moduleNames.map(function(i) {
-      return '• ' + i;
-    }).join('\n').replace(/^\s+/, '');
-    console.log('The following modules are loaded:\n' + moduleList);
-  }
 }());


### PR DESCRIPTION
- because there's no user need for it
- and it uses keys() that IE8 doesn't implement