### PR TITLE
Correctly specify path of feedback_success template

### DIFF
--- a/mtp_prisoner_location_admin/apps/feedback/urls.py
+++ b/mtp_prisoner_location_admin/apps/feedback/urls.py
@@ -16,6 +16,6 @@ urlpatterns = [
         }, name='submit_ticket'),
     url(r'^feedback/success/$', views.success,
         {
-            'template_name': 'feedback/success.html',
+            'template_name': 'mtp_common/feedback/success.html',
         }, name='feedback_success'),
 ]


### PR DESCRIPTION
The path changed as a result of changes to mtp-common